### PR TITLE
Fix Modrinth download badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MCG
 
 ![Discord Shield](https://discordapp.com/api/guilds/756203400089305128/widget.png?style=shield)
-![Modrinth Shield](https://img.shields.io/badge/dynamic/json?color=blue&label=Modrinth&query=downloads&url=https%3A%2F%2Fapi.modrinth.com%2Fapi%2Fv1%2Fmod%2FeVXHt0JE)
+![Modrinth Shield](https://img.shields.io/modrinth/dt/eVXHt0JE?color=blue&label=Modrinth)
 
 MCG provides quick and easy storage of coordinates, so they don't have to be stored outside of the game. Often, I found
 myself taking out a notepad to keep track of my coordinates.


### PR DESCRIPTION
v1 of Modrinth's API has been deprecated since January 2022 and is scheduled to begin breaking in February, with a complete breakage being done by March. This pull request has been created as a courtesy to update it to use the dedicated shields.io badge rather than manually constructing the API request.

After merging this PR, please also update any usages on other pages, for example a CurseForge and/or Modrinth project description, and also cherry-pick/copy these changes to any other branches you might have.